### PR TITLE
Exposed totalContentSize and allowed lazy calculation for sizing.

### DIFF
--- a/FSQCollectionViewAlignedLayout.h
+++ b/FSQCollectionViewAlignedLayout.h
@@ -74,6 +74,11 @@
  */
 @property (nonatomic) UIEdgeInsets contentInsets;
 
+/*
+ Total content size of all sections.
+ */
+@property (nonatomic, readonly) CGSize totalContentSize;
+
 @end
 
 

--- a/FSQCollectionViewAlignedLayout.m
+++ b/FSQCollectionViewAlignedLayout.m
@@ -338,6 +338,15 @@ CGFloat UIEdgeInsetsVerticalInset_fsq(UIEdgeInsets insets) {
     self.totalContentSize = totalSizeOfContent;
 }
 
+#pragma mark - Getters -
+
+- (CGSize)totalContentSize{
+  if(CGSizeEqualToSize(_totalContentSize, CGSizeZero)){
+    [self prepareLayout];
+  }
+  return _totalContentSize;
+}
+
 #pragma mark - Cells in Rect Calculations -
 
 /**


### PR DESCRIPTION
I have a lot of collectionViews in my app, and one of the things I do is use the collectionView layout size to set the size of the collectionView dynamically depending on the size of the content.

This PR just exposes the property you already had, and also prepares the layout if the content size is zero when the property is queried.
