### PR TITLE
Support load from nib.

### DIFF
--- a/FSQCollectionViewAlignedLayout.h
+++ b/FSQCollectionViewAlignedLayout.h
@@ -46,7 +46,7 @@
  
  Defaults to 100x100 cells if not set.
  */
-@property (nonatomic) CGSize defaultCellSize;
+@property (nonatomic) IBInspectable CGSize defaultCellSize;
 
 /** 
  Used if attributesForSectionAtIndex delegate method is not implemented
@@ -67,7 +67,7 @@
  
  Defaults to 10 if not set.
  */
-@property (nonatomic) CGFloat sectionSpacing;
+@property (nonatomic) IBInspectable CGFloat sectionSpacing;
 
 /** 
  Insets in points around the entire contents of the collection. Defaults to (5, 5, 5, 5) if not set

--- a/FSQCollectionViewAlignedLayout.m
+++ b/FSQCollectionViewAlignedLayout.m
@@ -98,6 +98,13 @@ CGFloat UIEdgeInsetsVerticalInset_fsq(UIEdgeInsets insets) {
     return self;
 }
 
+- (id)initWithCoder:(NSCoder *)aDecoder {
+    if ((self = [super initWithCoder:aDecoder])) {
+        [self setupDefaults];
+    }
+    return self;
+}
+
 - (void)setupDefaults {
     self.defaultSectionAttributes = [FSQCollectionViewAlignedLayoutSectionAttributes topLeftAlignment];
     self.defaultCellAttributes = [FSQCollectionViewAlignedLayoutCellAttributes defaultCellAttributes];


### PR DESCRIPTION
Hi there, FSQCollectionViewAlignedLayout was wonderful. But it doesn't work in my project. I create my views and FSQCollectionViewAlignedLayout object in storyboard. `collectionView:cellForItemAtIndexPath:` never called. After some investigation, I found FSQCollectionViewAlignedLayout not setup defaults when load from a nib.

This pull request will fix this. And also add some storyboard inspect support.
